### PR TITLE
fix: stabilize wasm test runs

### DIFF
--- a/diffsl/Cargo.toml
+++ b/diffsl/Cargo.toml
@@ -76,8 +76,13 @@ features = [
 bindgen = { version = "0.72", optional = true }
 cmake = { version = "0.1.54", optional = true }
 
+[dev-dependencies]
+paste = "1.0.15"
+
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 divan = "0.1.21"
+colog = "1.4.0"
+faer = "0.24.0"
 env_logger = "0.11.8"
 
 [[bench]]
@@ -87,11 +92,6 @@ harness = false
 [[bench]]
 name = "pybamm_dfn"
 harness = false
-
-[dev-dependencies]
-colog = "1.4.0"
-faer = "0.23.2"
-paste = "1.0.15"
 
 [package.metadata.docs.rs]
 features = ["llvm15-0"]

--- a/diffsl/src/parser/mod.rs
+++ b/diffsl/src/parser/mod.rs
@@ -20,22 +20,20 @@ use crate::ast::{self, Ast};
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
-
     use pest::Parser;
 
     use super::{MsParser, MsRule};
 
-    const MS_FILENAMES: &[&str] = &["test_circuit.ms", "test_fishers.ms", "test_pk.ms"];
-
-    const BASE_DIR: &str = "src/parser";
+    const MS_FILES: &[(&str, &str)] = &[
+        ("test_circuit.ms", include_str!("test_circuit.ms")),
+        ("test_fishers.ms", include_str!("test_fishers.ms")),
+        ("test_pk.ms", include_str!("test_pk.ms")),
+    ];
 
     #[test]
     fn parse_examples() {
-        for filename in MS_FILENAMES {
-            let unparsed_file =
-                fs::read_to_string(BASE_DIR.to_owned() + "/" + filename).expect("cannot read file");
-            let _list = MsParser::parse(MsRule::main, &unparsed_file)
+        for (filename, contents) in MS_FILES {
+            let _list = MsParser::parse(MsRule::main, contents)
                 .unwrap_or_else(|e| panic!("unsuccessful parse ({filename}) {e}"));
         }
     }

--- a/diffsl/tests/pybamm_dfn.rs
+++ b/diffsl/tests/pybamm_dfn.rs
@@ -1,21 +1,24 @@
+#[cfg(not(target_arch = "wasm32"))]
 use diffsl::{
     discretise::DiscreteModel, parser::parse_ds_string, CodegenModuleCompile, CodegenModuleJit,
     Compiler,
 };
+#[cfg(not(target_arch = "wasm32"))]
 use std::io::Write;
 
-#[cfg(feature = "llvm")]
+#[cfg(all(feature = "llvm", not(target_arch = "wasm32")))]
 #[test]
 fn test_dfn_model_initialization_llvm() {
     test_dfn_model_initialization::<diffsl::LlvmModule>();
 }
 
-#[cfg(feature = "cranelift")]
+#[cfg(all(feature = "cranelift", not(target_arch = "wasm32")))]
 #[test]
 fn test_dfn_model_initialization_cranelift() {
     test_dfn_model_initialization::<diffsl::CraneliftJitModule>();
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[allow(dead_code)]
 fn test_dfn_model_initialization<M: CodegenModuleJit + CodegenModuleCompile>() {
     let _ = env_logger::builder().is_test(true).try_init();


### PR DESCRIPTION
Summary:
- make parser example test use embedded files for wasm
- adjust wasm-related test behavior and dependencies
- clean up wasm-only warnings

Tests:
- cargo fmt
- cargo test
- cargo test --target wasm32-wasip1-threads (wasmtime runner)
- cargo clippy